### PR TITLE
fix: add kmod and util-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 
 TAG ?= $(shell $(BINDIR)/gitmeta image tag)
 
-TARGETS =  ca-certificates  cni  containerd  crictl  dosfstools  eudev  fhs  images  iptables  kernel  kubeadm  libressl  libseccomp  musl  runc  socat  syslinux  xfsprogs
+TARGETS =  ca-certificates  cni  containerd  crictl  dosfstools  eudev  fhs  images  iptables  kernel  kmod  kubeadm  libressl  libseccomp  musl  runc  socat  syslinux  util-linux  xfsprogs
 
 all: ci $(TARGETS)
 
@@ -94,4 +94,4 @@ $(TARGETS): buildkitd gitmeta
 
 .PHONY: deps.png
 deps.png:
-	bldr graph | dot -Tpng > deps.png	
+	bldr graph | dot -Tpng > deps.png

--- a/kmod/pkg.yaml
+++ b/kmod/pkg.yaml
@@ -1,0 +1,39 @@
+name: kmod
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: musl
+  - stage: ca-certificates
+steps:
+  - sources:
+      - url: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-25.tar.xz
+        destination: kmod.tar.xz
+        sha256: 7165e6496656159dcb909a91ed708a0fe273a4b128b4b1dc997ccb5189eef1cd
+        sha512: d579cd0cea24a06362a74927b7a3c777e9e01c990306e1032e4781cd441ffe435c70f2c2c4f6ae39eb1d857e622746411d5824d0c0d8bb79f91dc9fa51956252
+    prepare:
+      - |
+        tar -xJf kmod.tar.xz --strip-components=1
+
+        mkdir /bin
+        ln -sv /toolchain/bin/bash /bin/bash
+        ln -sv /toolchain/bin/bash /bin/sh
+        cp -R /toolchain/lib/gcc /lib
+        cp -R /toolchain/lib/libgcc* /lib
+
+        mkdir build
+        cd build
+        ../configure \
+            --prefix=${TOOLCHAIN}
+    build:
+      - |
+        cd build
+        make -j $(nproc)
+    install:
+      - |
+        cd build
+        make DESTDIR=/rootfs install
+        for target in depmod insmod modinfo modprobe rmmod; do ln -s ../bin/kmod /rootfs${TOOLCHAIN}/bin/$target; done
+finalize:
+  - from: /rootfs
+    to: /

--- a/util-linux/pkg.yaml
+++ b/util-linux/pkg.yaml
@@ -1,0 +1,44 @@
+name: util-linux
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: musl
+  - stage: ca-certificates
+steps:
+  - sources:
+      - url: https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.xz
+        destination: util-linux.tar.xz
+        sha256: 86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2
+        sha512: 267fedae24a874ee4dc558081f6b8d07b33b955b0635f3348f021c111c17f2e95c01b2cbf909fe13c6ca448cbcf23c658c75f72f25749aa65e99f68fabb94698
+    prepare:
+      - |
+        tar -xJf util-linux.tar.xz --strip-components=1
+
+        mkdir /bin
+        ln -sv /toolchain/bin/bash /bin/bash
+        ln -sv /toolchain/bin/bash /bin/sh
+        cp -R /toolchain/lib/gcc /lib
+        cp -R /toolchain/lib/libgcc* /lib
+
+        mkdir build
+        cd build
+        ../configure \
+            --prefix=${TOOLCHAIN} \
+            --without-python \
+            --disable-makeinstall-chown \
+            --without-systemdsystemunitdir \
+            --without-ncurses \
+            PKG_CONFIG=""
+    build:
+      - |
+        cd build
+        make -j $(nproc)
+    install:
+      - |
+        cd build
+        mkdir /rootfs
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
In previous versions of this repo we pushed the base stage, but we no
longer do. In projects outside of this one, we were pulling files from
the base image. This adds packages for those files.