### PR TITLE
fix: use util-linux stage for shared object dependency

### DIFF
--- a/syslinux/pkg.yaml
+++ b/syslinux/pkg.yaml
@@ -2,43 +2,40 @@ name: syslinux
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
-- stage: base
-- stage: musl
-- stage: ca-certificates
+  - stage: base
+  - stage: musl
+  - stage: ca-certificates
+  - stage: util-linux
 steps:
-- sources:
-  - url: https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
-    destination: syslinux.tar.xz
-    sha256: 26d3986d2bea109d5dc0e4f8c4822a459276cf021125e8c9f23c3cca5d8c850e
-    sha512: dd2b2916962b9e93bc1e714182e3ca2a727a229b8afabe913050bcfdd43ee2af51ee3acf79121d8c20caf434583efaa7f3196871e0e07c04d82191323a50fe31
-  prepare:
-  - |
-    tar -xJf syslinux.tar.xz --strip-components=1
+  - sources:
+      - url: https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
+        destination: syslinux.tar.xz
+        sha256: 26d3986d2bea109d5dc0e4f8c4822a459276cf021125e8c9f23c3cca5d8c850e
+        sha512: dd2b2916962b9e93bc1e714182e3ca2a727a229b8afabe913050bcfdd43ee2af51ee3acf79121d8c20caf434583efaa7f3196871e0e07c04d82191323a50fe31
+    prepare:
+      - |
+        tar -xJf syslinux.tar.xz --strip-components=1
 
-    mkdir /bin
-    ln -sv /toolchain/bin/bash /bin/bash
-    ln -sv /toolchain/bin/bash /bin/sh
-    ln -sv /toolchain/bin/pwd /bin/pwd
-    cp -R /toolchain/lib/gcc /lib
-    cp -R /toolchain/lib/libgcc* /lib
-
-    # TODO(andrewrynhard): Add a util-linux package in this repo and pull these from there.
-    cp /toolchain/lib/libuuid* /lib
-  build:
-  - |
-    make -j $(nproc) installer
-  install:
-  - |
-    mkdir -p /rootfs/bin
-    cp bios/extlinux/extlinux /rootfs/bin
-    mkdir -p /rootfs/usr/lib/syslinux
-    cp efi64/mbr/gptmbr.bin /rootfs/usr/lib/syslinux/
-    # UEFI
-    cp efi64/efi/syslinux.efi /rootfs/usr/lib/syslinux/
-    cp efi64/com32/elflink/ldlinux/ldlinux.e64 /rootfs/usr/lib/syslinux/
-    # ISO
-    cp bios/core/isolinux.bin /rootfs/usr/lib/syslinux/
-    cp bios/com32/elflink/ldlinux/ldlinux.c32 /rootfs/usr/lib/syslinux/
+        ln -sv /toolchain/bin/bash /bin/bash
+        ln -sv /toolchain/bin/bash /bin/sh
+        ln -sv /toolchain/bin/pwd /bin/pwd
+        cp -R /toolchain/lib/gcc /lib
+        cp -R /toolchain/lib/libgcc* /lib
+    build:
+      - |
+        make -j $(nproc) installer
+    install:
+      - |
+        mkdir -p /rootfs/bin
+        cp bios/extlinux/extlinux /rootfs/bin
+        mkdir -p /rootfs/usr/lib/syslinux
+        cp efi64/mbr/gptmbr.bin /rootfs/usr/lib/syslinux/
+        # UEFI
+        cp efi64/efi/syslinux.efi /rootfs/usr/lib/syslinux/
+        cp efi64/com32/elflink/ldlinux/ldlinux.e64 /rootfs/usr/lib/syslinux/
+        # ISO
+        cp bios/core/isolinux.bin /rootfs/usr/lib/syslinux/
+        cp bios/com32/elflink/ldlinux/ldlinux.c32 /rootfs/usr/lib/syslinux/
 finalize:
-- from: /rootfs
-  to: /
+  - from: /rootfs
+    to: /

--- a/xfsprogs/pkg.yaml
+++ b/xfsprogs/pkg.yaml
@@ -2,38 +2,34 @@ name: xfsprogs
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
-- stage: base
-- stage: musl
-- stage: ca-certificates
+  - stage: base
+  - stage: musl
+  - stage: ca-certificates
+  - stage: util-linux
 steps:
-- sources:
-  - url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-4.18.0.tar.xz
-    destination: xfsprogs.tar.xz
-    sha256: 397dc96f51aeeff73d021d3418d3172377b2685f2740ca60525096c070aa3df1
-    sha512: 0629400f8824620138928a7d72908b7a852408814238a55e11d6eb3b2da42cd56273960430d3ea729a9bce95f605d225607940d4728b68c468c39eb5a9a590be
-  prepare:
-  - |
-    tar -xJf xfsprogs.tar.xz --strip-components=1
+  - sources:
+      - url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-4.18.0.tar.xz
+        destination: xfsprogs.tar.xz
+        sha256: 397dc96f51aeeff73d021d3418d3172377b2685f2740ca60525096c070aa3df1
+        sha512: 0629400f8824620138928a7d72908b7a852408814238a55e11d6eb3b2da42cd56273960430d3ea729a9bce95f605d225607940d4728b68c468c39eb5a9a590be
+    prepare:
+      - |
+        tar -xJf xfsprogs.tar.xz --strip-components=1
 
-    mkdir /bin
-    ln -sv /toolchain/bin/bash /bin/bash
-    ln -sv /toolchain/bin/bash /bin/sh
-    cp -R /toolchain/lib/gcc /lib
-    cp -R /toolchain/lib/libgcc* /lib
+        ln -sv /toolchain/bin/bash /bin/bash
+        ln -sv /toolchain/bin/bash /bin/sh
+        cp -R /toolchain/lib/gcc /lib
+        cp -R /toolchain/lib/libgcc* /lib
 
-    # TODO(andrewrynhard): Add a util-linux package in this repo and pull these from there.
-    cp /toolchain/lib/libuuid* /lib
-    cp /toolchain/lib/libblkid* /lib
-
-    ./configure \
-    --prefix=/ \
-    --enable-gettext=no
-  build:
-  - |
-    make -j $(nproc) DEBUG=-DNDEBUG
-  install:
-  - |
-    make install DESTDIR=/rootfs
+        ./configure \
+        --prefix=/ \
+        --enable-gettext=no
+    build:
+      - |
+        make -j $(nproc) DEBUG=-DNDEBUG
+    install:
+      - |
+        make install DESTDIR=/rootfs
 finalize:
-- from: /rootfs
-  to: /
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
There are a few places where we are copying shared objects from the
toolchain's /lib. This moves to using the util-linux stage instead. This
ensures that all packages are being built against the version of
util-linux in this repo.