### PR TITLE
fix: use default search path

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,4 +3,4 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: docker.io/autonomy/tools:8fdb32d
+  TOOLS_IMAGE: docker.io/autonomy/tools:d048c99

--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -19,8 +19,6 @@ steps:
       - |
         export PKG_CONFIG_PATH=/usr/lib/pkgconfig
         export CC=/toolchain/bin/cc
-        export CGO_CFLAGS="-L/usr/lib -I/usr/include"
-        export CGO_LDFLAGS="-L/usr/lib -I/usr/include"
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
         export GOPATH=/go

--- a/dosfstools/pkg.yaml
+++ b/dosfstools/pkg.yaml
@@ -17,7 +17,7 @@ steps:
         cd build
 
         ../configure \
-        --prefix=/ \
+        --prefix=/usr \
         --enable-compat-symlinks
     build:
       - |

--- a/eudev/pkg.yaml
+++ b/eudev/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
+  - stage: util-linux
 steps:
   - sources:
       - url: https://dev.gentoo.org/~blueness/eudev/eudev-3.2.8.tar.gz
@@ -19,7 +20,6 @@ steps:
         cat > config.cache << "EOF"
         HAVE_BLKID=1
         BLKID_LIBS="-lblkid"
-        BLKID_CFLAGS="-I${TOOLCHAIN}/include"
         EOF
 
         mkdir build

--- a/kmod/pkg.yaml
+++ b/kmod/pkg.yaml
@@ -16,7 +16,7 @@ steps:
         mkdir build
         cd build
         ../configure \
-            --prefix=/
+            --prefix=/usr
     build:
       - |
         cd build
@@ -25,7 +25,7 @@ steps:
       - |
         cd build
         make DESTDIR=/rootfs install
-        for target in depmod insmod modinfo modprobe rmmod; do ln -s ../bin/kmod /rootfs/bin/$target; done
+        for target in depmod insmod modinfo modprobe rmmod; do ln -s ../usr/bin/kmod /rootfs/usr/bin/$target; done
 finalize:
   - from: /rootfs
     to: /

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -21,9 +21,12 @@ steps:
         mkdir build
         cd build
 
+        # From https://www.musl-libc.org/doc/1.0.0/manual.html:
+        #    $(syslibdir), $(includedir), and $(libdir) refer to the paths
+        #    chosen at build time (by default, /lib, $(prefix)/include, and
+        #    $(prefix)/lib, respectively)
         ../configure \
-        --prefix=/ \
-        --syslibdir=/lib \
+        --prefix=/usr
     build:
       - |
         cd build

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -24,8 +24,6 @@ steps:
         export PATH=${PATH}:/${TOOLCHAIN}/go/bin
         export PKG_CONFIG_PATH=/usr/lib/pkgconfig
         export CC=/toolchain/bin/cc
-        export CGO_CFLAGS="-L/usr/lib -I/usr/include"
-        export CGO_LDFLAGS="-L/usr/lib -I/usr/include"
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
         make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=d736ef14f0288d6993a1845745d6756cfc9ddd5a runc

--- a/socat/pkg.yaml
+++ b/socat/pkg.yaml
@@ -15,8 +15,7 @@ steps:
         tar -xzf socat.tar.gz --strip-components=1
 
         ./configure \
-            --prefix=/usr \
-            LIBS="-L/usr/lib"
+            --prefix=/usr
     build:
       - |
         make -j $(nproc)

--- a/util-linux/pkg.yaml
+++ b/util-linux/pkg.yaml
@@ -16,7 +16,7 @@ steps:
         mkdir build
         cd build
         ../configure \
-            --prefix=/ \
+            --prefix=/usr \
             --without-python \
             --disable-makeinstall-chown \
             --without-systemdsystemunitdir \

--- a/xfsprogs/pkg.yaml
+++ b/xfsprogs/pkg.yaml
@@ -15,7 +15,7 @@ steps:
         tar -xJf xfsprogs.tar.xz --strip-components=1
 
         ./configure \
-        --prefix=/ \
+        --prefix=/usr \
         --enable-gettext=no
     build:
       - |


### PR DESCRIPTION
In previous versions of the toolchain we had a misconfigured linker that
did not have /usr/lib in its search path. This brings in a version of
the toolchain that does, and removes all the hacks we did to work around
this.