### PR TITLE
chore: update all packages with latest versions

### DIFF
--- a/ca-certificates/pkg.yaml
+++ b/ca-certificates/pkg.yaml
@@ -1,10 +1,10 @@
 name: ca-certificates
 steps:
   - sources:
-      - url: https://curl.haxx.se/ca/cacert-2019-11-27.pem
+      - url: https://curl.haxx.se/ca/cacert-2020-01-01.pem
         destination: cacert.pem
-        sha256: 0d98a1a961aab523c9dc547e315e1d79e887dea575426ff03567e455fc0b66b4
-        sha512: 66816e077ee99ceb9535a472e6bbf4f0e48ca838099c8a97c7baf3297fcada9a43016ea1ded63a455ee56a8f18501417a0f744fc17b215bb599cafd76b754518
+        sha256: adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f
+        sha512: cc129ae1a4377a43a74b0854b6eccb2b315cdfce018142d1dd5524fb64c8945cde067cb18f366351fa7d6af3f9f36cf21bc1f626f987f9e4627878472ea59cde
     install:
       - |
         mkdir -p /rootfs/etc/ssl/certs

--- a/cni/pkg.yaml
+++ b/cni/pkg.yaml
@@ -1,14 +1,14 @@
 name: cni
 steps:
   - sources:
-      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz
+      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz
         destination: cni-plugins-amd64.tgz
-        sha256: 21283754ffb953329388b5a3c52cef7d656d535292bda2d86fcdda604b482f85
-        sha512: a8fd7ffce7f4f1fb00ac2e4840b7961efc3ec844c5e99035c72baa95f038b316552ce71f8a17f82c04d614da490689953a7a80008d7b9be563187673813934b5
-      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-arm-v0.8.2.tgz
+        sha256: bd682ffcf701e8f83283cdff7281aad0c83b02a56084d6e601216210732833f9
+        sha512: 497be012e1e3c605c467752ee5729de35d88afd7a0bfa237a6cf979413d65bda34865a8dd952ca1d32581bb5669d567c2c7f2d23dd92db3ba9101204583a8482
+      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-arm-v0.8.5.tgz
         destination: cni-plugins-arm64.tgz
-        sha256: d18d89fc82c8382b7b291e086f80188c143682e48c53ee25f522763c9395d0d9
-        sha512: 897004bcffe69f2079be06591e6b3a5e1721a923db940df6fa2396cfb906b7b721c5f3e08350d023ffaf16abb76d59571be9ee97c26e3cd7204c6483ce51c42a
+        sha256: 86a868234045837cb3f5d58a0a4468ff42845d50b5e87bd128f050ef393d7495
+        sha512: 3c03b76db4ec92c0121c22f27d552fd2323c70a14f82baac1ec22392baf8c6b55c453bbcd658fbd67a8468417d672478f01c8dab7766074c2d7536c9b60a1266
     install:
       - |
         mkdir -p /rootfs/opt/cni/bin

--- a/iptables/pkg.yaml
+++ b/iptables/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://netfilter.org/projects/iptables/files/iptables-1.8.3.tar.bz2
+      - url: https://netfilter.org/projects/iptables/files/iptables-1.8.4.tar.bz2
         destination: iptables.tar.bz2
-        sha256: a23cac034181206b4545f4e7e730e76e08b5f3dd78771ba9645a6756de9cdd80
-        sha512: 84b10080646077cbea78b7f3fcc58c6c6e1898213341c69862e1b48179f37a6820c3d84437c896071f966b61aa6d16b132d91948a85fd8c05740f29be3a0986d
+        sha256: 993a3a5490a544c2cbf2ef15cf7e7ed21af1845baf228318d5c36ef8827e157c
+        sha512: a7faaab58608ffaa51e26e8056551c0e91a49187439d30fcf5cce2800274cc3c0515db6cfba0f4c85613fb80779cf96089b8915db0e89161e9980a6384faebdb
     prepare:
       - |
         tar -xjf iptables.tar.bz2 --strip-components=1

--- a/kmod/pkg.yaml
+++ b/kmod/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-26.tar.xz
+      - url: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-27.tar.xz
         destination: kmod.tar.xz
-        sha256: 57bb22c8bb56435991f6b0810a042b0a65e2f1e217551efa58235b7034cdbb9d
-        sha512: 3ca276c6fc13c2dd2220ec528b8dc4ab4edee5d2b22e16b6f945c552e51f74342c01c33a53740e6af8c893d42bd4d6f629cd8fa6e15ef8bd8da30cb003ef0865
+        sha256: c1d3fbf16ca24b95f334c1de1b46f17bbe5a10b0e81e72668bdc922ebffbbc0c
+        sha512: e0513094935333fca1fb4c3e3493b232507a579ab00a6457cc9ed3e928363d05aad80634fb65a8287a336bf9895194c7be8ddc41bb088a6c2cca44fc1bfbdb6c
     prepare:
       - |
         tar -xJf kmod.tar.xz --strip-components=1

--- a/libseccomp/pkg.yaml
+++ b/libseccomp/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/seccomp/libseccomp/releases/download/v2.4.2/libseccomp-2.4.2.tar.gz
+      - url: https://github.com/seccomp/libseccomp/releases/download/v2.4.3/libseccomp-2.4.3.tar.gz
         destination: libseccomp.tar.gz
-        sha256: b54f27b53884caacc932e75e6b44304ac83586e2abe7a83eca6daecc5440585b
-        sha512: 375a3c7c658be6a08b9bb30963e10bb49e8e066119e0be6d3d97faac3db18b8e2c6938d8b5d3874b2f5331ec8295170112fbae83b5a3b5a5bebc0d6705bdfdbb
+        sha256: cf15d1421997fac45b936515af61d209c4fd788af11005d212b3d0fd71e7991d
+        sha512: 7b7af2e98493243ffe1934fefff5723b24ae9b9bdc4bf039343ee8456c15acb0ea34e81ec292a41143848272aeca794ef92ad38fc3f42c77465170cb540479ef
     prepare:
       - |
         tar -xzf libseccomp.tar.gz --strip-components=1

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: "{{ .TOOLS_IMAGE }}"
 steps:
   - sources:
-      - url: https://www.musl-libc.org/releases/musl-1.1.24.tar.gz
+      - url: https://www.musl-libc.org/releases/musl-1.2.0.tar.gz
         destination: musl.tar.gz
-        sha256: 1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
-        sha512: 8987f1e194ea616f34f4f21fe9def28fb7f81d7060e38619206c6349f79db3bbb76bae8b711f5f9b8ed038799c9aea1a4cbec69e0bc4131e246203e133149e77
+        sha256: c6de7b191139142d3f9a7b5b702c9cae1b5ee6e7f57e582da9328629408fd4e8
+        sha512: 58bd88189a6002356728cea1c6f6605a893fe54f7687595879add4eab283c8692c3b031eb9457ad00d1edd082cfe62fcc0eb5eb1d3bf4f1d749c0efa2a95fec1
     prepare:
       - |
         export PATH=${TOOLCHAIN}/cross/bin:${PATH}

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: libseccomp
 steps:
   - sources:
-      - url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc9/runc.tar.xz
+      - url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc10/runc.tar.xz
         destination: runc.tar.xz
-        sha256: 2f1c7ebac67c779affe2bb4370bba44b08ed280144ba58c86219186e303832ba
-        sha512: 881135c95d8063c4a3ad23bc8f7858ba6cb864cc31484b10549e7808959d1c2405bdb09737855e870a0c656d7d1eb5756b2dec714e8877a9f201e33502589299
+        sha256: c823307ce8695af05381c5c25a92daacd6219c674d8bebaa0e1bff801c2b1f24
+        sha512: e8e897a7b4fb7be0c30350ba058f143c7f6cb703dc1803d825327fb1b1f12dc903eab5a8a466e7bbd2858b291e3e6d71d864b193f8c3117fb5e68a5c481f8eb0
     prepare:
       - |
         export GOPATH=/go

--- a/socat/pkg.yaml
+++ b/socat/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: libressl
 steps:
   - sources:
-      - url: http://www.dest-unreach.org/socat/download/socat-1.7.3.3.tar.gz
+      - url: http://www.dest-unreach.org/socat/download/socat-1.7.3.4.tar.gz
         destination: socat.tar.gz
-        sha256: 8cc0eaee73e646001c64adaab3e496ed20d4d729aaaf939df2a761e99c674372
-        sha512: b3ea4cb6081f7778a0281a3ec36ea7e5daf07dc19f2e0de08f767417112776e96e1bcac7962ebb6dd8b960ad91fc4a452f0da8327736d50e215e4ab43947ff78
+        sha256: d9ed2075abed7b3ec9730ed729b4c8e287c502181c806d4487020418a6e2fc36
+        sha512: c5699fd1a703e90927076599d02323b85722d49e86bc2f627b4301a41d3df72c634af629f378425ff201cde78343da5cd0cad1044bf857665176c91357401fdd
     prepare:
       - |
         tar -xzf socat.tar.gz --strip-components=1

--- a/util-linux/pkg.yaml
+++ b/util-linux/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.xz
+      - url: https://www.kernel.org/pub/linux/utils/util-linux/v2.35/util-linux-2.35.1.tar.xz
         destination: util-linux.tar.xz
-        sha256: 86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2
-        sha512: 267fedae24a874ee4dc558081f6b8d07b33b955b0635f3348f021c111c17f2e95c01b2cbf909fe13c6ca448cbcf23c658c75f72f25749aa65e99f68fabb94698
+        sha256: d9de3edd287366cd908e77677514b9387b22bc7b88f45b83e1922c3597f1d7f9
+        sha512: 6e27e08bfc02378970f015decfea5a52d6c342c4c8f4ac48dd07d248485eb797e506d91d290dbbca344c3e5cfe1fc150db80a23d510367427232f5abeabe591a
     prepare:
       - |
         tar -xJf util-linux.tar.xz --strip-components=1

--- a/xfsprogs/pkg.yaml
+++ b/xfsprogs/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: util-linux
 steps:
   - sources:
-      - url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-5.2.1.tar.xz
+      - url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-5.5.0.tar.xz
         destination: xfsprogs.tar.xz
-        sha256: 7b500e148cebd08f99e37cf744c7843817b37e7be2a32c4dc57d6ea16e3019ae
-        sha512: a2ecd8e2ae8a4e7357b4133beaeffeae4d6c9d0ece9855d9780a84c2d4072e3d4e0b8ffa3baa995862ec38dcbc5dd74205f7f4456676826082c4811867508a43
+        sha256: cfbb0b136799c48cb79435facd0969c5a60a587a458e2d16f9752771027efbec
+        sha512: 1169765e9a003f9618f020eb190dc0a692e7017cf1ec2a9329a8db0f07ef6a48cb250fc326fb9168714259c8d5f2195cc6fd41e01bbbdc9a5857e53f145b6815
     prepare:
       - |
         tar -xJf xfsprogs.tar.xz --strip-components=1


### PR DESCRIPTION
This PR updates all of our packages if they needed updates

Updated packages:

- ca-certificates
- cni
- iptables
- kmod
- libseccomp
- musl
- runc
- socat
- util-linux
- xfsprogs

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>