### PR TITLE
chore: bump tools for Go update to version 1.14.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,4 +3,4 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: docker.io/autonomy/tools:v0.2.0
+  TOOLS_IMAGE: docker.io/autonomy/tools:v0.2.0-1-g418e800


### PR DESCRIPTION
See talos-systems/tools#92

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>