### PR TITLE
feat: update pkgs for talos v0.6.x release cycle

### DIFF
--- a/cni/pkg.yaml
+++ b/cni/pkg.yaml
@@ -1,14 +1,14 @@
 name: cni
 steps:
   - sources:
-      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz
+      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
         destination: cni-plugins-amd64.tgz
-        sha256: bd682ffcf701e8f83283cdff7281aad0c83b02a56084d6e601216210732833f9
-        sha512: 497be012e1e3c605c467752ee5729de35d88afd7a0bfa237a6cf979413d65bda34865a8dd952ca1d32581bb5669d567c2c7f2d23dd92db3ba9101204583a8482
-      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-arm-v0.8.5.tgz
+        sha256: 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5
+        sha512: 76b29cc629449723fef45db6a6999b0617e6c9084678a4a3361caf3fc5e935084bc0644e47839b1891395e3cec984f7bfe581dd9455c4991ddeee1c78392e538
+      - url: https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-arm-v0.8.6.tgz
         destination: cni-plugins-arm64.tgz
-        sha256: 86a868234045837cb3f5d58a0a4468ff42845d50b5e87bd128f050ef393d7495
-        sha512: 3c03b76db4ec92c0121c22f27d552fd2323c70a14f82baac1ec22392baf8c6b55c453bbcd658fbd67a8468417d672478f01c8dab7766074c2d7536c9b60a1266
+        sha256: 28e61b5847265135dc1ca397bf94322ecce4acab5c79cc7d360ca3f6a655bdb7
+        sha512: 7cb8eff0d7663b9814e400573487e87717c13aa904a9ab3f055496f3485d0eaca88236f8a806685604291110c0e8ba6311ed2ec26d71cf53e95ecfc9087ed20a
     install:
       - |
         mkdir -p /rootfs/opt/cni/bin

--- a/iptables/pkg.yaml
+++ b/iptables/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://netfilter.org/projects/iptables/files/iptables-1.8.4.tar.bz2
+      - url: https://netfilter.org/projects/iptables/files/iptables-1.8.5.tar.bz2
         destination: iptables.tar.bz2
-        sha256: 993a3a5490a544c2cbf2ef15cf7e7ed21af1845baf228318d5c36ef8827e157c
-        sha512: a7faaab58608ffaa51e26e8056551c0e91a49187439d30fcf5cce2800274cc3c0515db6cfba0f4c85613fb80779cf96089b8915db0e89161e9980a6384faebdb
+        sha256: d457d74512e63aa3f50336e0597d4023c0e3c6845594d38532efb6ebcb294309
+        sha512: 6a6baa541bb7aa331b176e0a91894e0766859814b59e77c71351ac34d6ebd337487981db48c70e476a48c67bcf891cfc663221a7582feb1496ad1df56eb28da8
     prepare:
       - |
         tar -xjf iptables.tar.bz2 --strip-components=1

--- a/libressl/pkg.yaml
+++ b/libressl/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.0.2.tar.gz
+      - url: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.0.tar.gz
         destination: libressl.tar.gz
-        sha256: df7b172bf79b957dd27ef36dcaa1fb162562c0e8999e194aa8c1a3df2f15398e
-        sha512: 19226da3bc9776e1da40b8e94dfa53564d5e6acc80edee539ba12d7a75c1bb8c0603e7633f26a6ef8b12adc56bb677ccda448575aa6be2ad3df5447465a4b080
+        sha256: 47bd2eb4b4503e47c02efa7e67d2fcd95c7eac6bc9d06b343a1b4705793ed1d5
+        sha512: e8bf95af4e4e855b0462eb12df8f802102a3bee5bb40fb1859e7c40d9e3ce89f0d2eb0acdd923e7c592b4aeb7ecc556f753c0a12d0dace05d2ef342bffdd9d07
     prepare:
       - |
         tar -xzf libressl.tar.gz --strip-components=1

--- a/linux-firmware/pkg.yaml
+++ b/linux-firmware/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
     - image: '{{ .TOOLS_IMAGE }}'
 steps:
     - sources:
-          - url: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20200316.tar.gz
+          - url: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20200519.tar.gz
             destination: linux-firmware.tar.gz
-            sha256: b442ad49e0002c6ff8443f4745810fe10d4cd6df43a7ce5e37ac40057c75ac13
-            sha512: 2fb16fcc474753902ab0236cbb116cdd5de10080d5ad5fc19a015ad3881a203c42beeccf5745e18346fc028a5c743d3d6439f0a04b86b2e0abf9f32aa5f55bad
+            sha256: b33b727f0ae299c65cb7ddf1cc3ab3ebe50085bd50694fd3af7fd7f07303476c
+            sha512: 9724cf3d1aea73f264d53564ef160a62e90bb35766f3300bbbeaf7c7c6a356ef50c7d17bfa01197e8e991ff72b1aeef002bb78f5dc78243b2792cafbf1139dff
       prepare:
           - |
               mkdir -p lib/firmware

--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
   - stage: eudev
 steps:
   - sources:
-      - url: https://mirrors.kernel.org/sourceware/lvm2/LVM2.2.03.07.tgz
+      - url: https://mirrors.kernel.org/sourceware/lvm2/LVM2.2.03.09.tgz
         destination: lvm2.tar.gz
-        sha256: c72f1095c82ca884c0f46c003a0da9b60b68554a8c913ca6c29d01fae04301e9
-        sha512: f1cefde32370140ccc802c467fe1e7e40b2ab99c1367fc03457e34640bdc9c0481523c2360e6ac18d6ae5ae9e80bc5dff61b3d13d20b1592bbee27e04fe1fd24
+        sha256: c03a8b8d5c03ba8ac54ebddf670ae0d086edac54a6577e8c50721a8e174eb975
+        sha512: 8540e46a6025ab14b592ccd9493b3224ffc0f962739a0a8de6d7b25c65c6ad96fc83ddb0e3d877b123a5e1b104476d0c20ccee2ead6d322257ec82ad1e3362d4
     prepare:
       - |
         tar -xzf lvm2.tar.gz --strip-components=1

--- a/xfsprogs/pkg.yaml
+++ b/xfsprogs/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: util-linux
 steps:
   - sources:
-      - url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-5.5.0.tar.xz
+      - url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-5.6.0.tar.xz
         destination: xfsprogs.tar.xz
-        sha256: cfbb0b136799c48cb79435facd0969c5a60a587a458e2d16f9752771027efbec
-        sha512: 1169765e9a003f9618f020eb190dc0a692e7017cf1ec2a9329a8db0f07ef6a48cb250fc326fb9168714259c8d5f2195cc6fd41e01bbbdc9a5857e53f145b6815
+        sha256: 0aba2aac5d80d07646dde868437fc337af2c7326edadcc6d6a7c0bfd3190c1e6
+        sha512: a6bee55b0a23316c73f3921234d1dbaa4cbe91c12e79264e5f9bfe1356a24baa0ab25270405a46e4613a7e48443ef21997ff4f5962663777bed373f89ca29701
     prepare:
       - |
         tar -xJf xfsprogs.tar.xz --strip-components=1


### PR DESCRIPTION
This PR bundles various pkg updates. Packages updated are:

- CNI
- IPTables
- LibreSSL
- Linux Firmware
- LVM2
- XFS Progs