### PR TITLE
fix: publish libaio and disable buffering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ COMMON_ARGS := --file=Pkgfile
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 
-TARGETS =  ca-certificates  cni  containerd  dosfstools  eudev  fhs  ipmitool  iptables  kernel  kmod  libressl  libseccomp  linux-firmware lvm2  musl  runc  socat  syslinux  util-linux  xfsprogs
+TARGETS =  ca-certificates  cni  containerd  dosfstools  eudev  fhs  ipmitool  iptables  kernel  kmod  libaio  libressl  libseccomp  linux-firmware lvm2  musl  runc  socat  syslinux  util-linux  xfsprogs
 
 all: $(TARGETS) ## Builds all known pkgs.
 

--- a/lvm2/patches/disable-create_toolcontext-buffering.patch
+++ b/lvm2/patches/disable-create_toolcontext-buffering.patch
@@ -1,0 +1,25 @@
+diff -ruN old/lib/mm/memlock.c new/lib/mm/memlock.c
+--- old/lib/mm/memlock.c	2020-03-26 11:26:37.000000000 +0000
++++ new/lib/mm/memlock.c	2020-06-12 17:57:46.230654829 +0000
+@@ -221,7 +221,9 @@
+ 
+ static void _release_memory(void)
+ {
++#if 0
+ 	free(_malloc_mem);
++#endif
+ }
+ 
+ /*
+diff -ruN old/tools/lvmcmdline.c new/tools/lvmcmdline.c
+--- old/tools/lvmcmdline.c	2020-03-26 11:26:37.000000000 +0000
++++ new/tools/lvmcmdline.c	2020-06-12 17:42:44.476090689 +0000
+@@ -3438,7 +3438,7 @@
+ 	 */
+ 	dm_set_name_mangling_mode(DM_STRING_MANGLING_NONE);
+ 
+-	if (!(cmd = create_toolcontext(0, NULL, 1, 0,
++	if (!(cmd = create_toolcontext(0, NULL, 0, 0,
+ 			set_connections, set_filters))) {
+ 		udev_fin_library_context();
+ 		return_NULL;

--- a/lvm2/patches/mlockall-default-config.patch
+++ b/lvm2/patches/mlockall-default-config.patch
@@ -1,0 +1,22 @@
+--- ./conf/example.conf.in.orig
++++ ./conf/example.conf.in
+@@ -1352,7 +1352,7 @@
+ 	# Use the old behavior of mlockall to pin all memory.
+ 	# Prior to version 2.02.62, LVM used mlockall() to pin the whole
+ 	# process's memory while activating devices.
+-	use_mlockall = 0
++	use_mlockall = 1
+ 
+ 	# Configuration option activation/monitoring.
+ 	# Monitor LVs that are activated.
+--- ./lib/config/defaults.h.orig
++++ ./lib/config/defaults.h
+@@ -55,7 +55,7 @@
+ #define DEFAULT_LVMLOCKD_LOCK_RETRIES 3
+ #define DEFAULT_LVMETAD_UPDATE_WAIT_TIME 10
+ #define DEFAULT_PRIORITISE_WRITE_LOCKS 1
+-#define DEFAULT_USE_MLOCKALL 0
++#define DEFAULT_USE_MLOCKALL 1
+ #define DEFAULT_METADATA_READ_ONLY 0
+ #define DEFAULT_LVDISPLAY_SHOWS_FULL_DEVICE_PATH 0
+ #define DEFAULT_UNKNOWN_DEVICE_NAME "[unknown]"

--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -17,6 +17,8 @@ steps:
 
         patch -p0 < /pkg/patches/mallinfo.patch
         patch -p0 < /pkg/patches/fix-stdio-usage.patch
+        patch -p0 < /pkg/patches/mlockall-default-config.patch
+        patch -p1 < /pkg/patches/disable-create_toolcontext-buffering.patch
 
         mkdir build
         cd build
@@ -28,6 +30,9 @@ steps:
              --with-cache=none \
              --disable-udev-systemd-background-jobs \
              --with-systemdsystemunitdir=/dev/null \
+             --localstatedir=/var \
+             --disable-nls \
+             --disable-readline \
              --disable-selinux \
              --enable-cmdlib \
              --enable-pkgconfig \


### PR DESCRIPTION
LVM2 depends on libaio. This patch ensures that we publish libaio.
There also is a change in newer versions of musl that causes LVM2
to segfault because stdout/stderr is closed. This adds a patch that
disables buffering in create_toolcontext function to prevent the
segfault.