### PR TITLE
fix: update the way variable with space is set for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 
 , := ,
-space :=
-space +=
+empty :=
+space = $(empty) $(empty)
 
 TARGETS =  ca-certificates  cni  containerd  dosfstools  eudev  fhs  grub  ipmitool  iptables  kernel  kmod  libaio  libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns  runc  socat  syslinux  util-linux  xfsprogs
 


### PR DESCRIPTION
Previous solution doesn't work for `make` >= 4.3.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>