### PR TITLE
feat: add `cryptsetup` build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMMON_ARGS += --platform=$(PLATFORM)
 empty :=
 space = $(empty) $(empty)
 
-TARGETS =  ca-certificates  cni  containerd  dosfstools  eudev  fhs  grub  ipmitool  iptables  kernel  kmod  libaio  libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns  runc  socat  syslinux  util-linux  xfsprogs
+TARGETS =  ca-certificates  cni  containerd cryptsetup dosfstools  eudev  fhs  grub  ipmitool  iptables  kernel  kmod  libaio  libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns  runc  socat  syslinux  util-linux  xfsprogs
 
 all: $(TARGETS) ## Builds all known pkgs.
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,4 +3,4 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: docker.io/autonomy/tools:v0.2.0-8-g7e14b0a
+  TOOLS_IMAGE: docker.io/autonomy/tools:v0.2.0-9-g546446a

--- a/cryptsetup/pkg.yaml
+++ b/cryptsetup/pkg.yaml
@@ -1,0 +1,35 @@
+name: cryptsetup
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: eudev # dependency for libdevmapper
+  - stage: lvm2 # libdevmapper
+  - stage: util-linux # libuuid
+  - stage: libpopt
+  - stage: libjson-c
+  - stage: libressl
+steps:
+  - sources:
+      - url: https://www.kernel.org/pub/linux/utils/cryptsetup/v2.3/cryptsetup-2.3.3.tar.gz
+        destination: cryptsetup.tar.gz
+        sha256: 87159ec22130b0cb1b3fd5e7754b6d731294e27c124b99fe73bd6d072641ab58
+        sha512: 0dbcc68fa72caff19082eb00815a62498caf28f37d73bafa9212125500be9386ce322c2f63cc5ff1808de7c1ca983872c9122b7a12dfe360580a6d096dcbc1ed
+    env:
+      PKG_CONFIG_PATH: /usr/lib/pkgconfig
+    prepare:
+      - |
+        tar -xzf cryptsetup.tar.gz --strip-components=1
+
+        ./configure \
+          --prefix=/usr \
+          --enable-static-cryptsetup || (cat config.log; exit 1)
+    build:
+      - |
+        make -j $(nproc)
+    install:
+      - |
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/eudev/pkg.yaml
+++ b/eudev/pkg.yaml
@@ -30,8 +30,7 @@ steps:
           --libexecdir=/usr/libexec \
           --sbindir=/sbin \
           --disable-manpages \
-          --enable-hwdb \
-          --disable-static
+          --enable-hwdb
     build:
       - |
         cd build

--- a/libjson-c/pkg.yaml
+++ b/libjson-c/pkg.yaml
@@ -1,0 +1,31 @@
+name: libjson-c
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.15.tar.gz
+        destination: json-c.tar.gz
+        sha256: b8d80a1ddb718b3ba7492916237bbf86609e9709fb007e7f7d4322f02341a4c6
+        sha512: dc01298bcc78f0f31a34f5fcfe45c0feebfd88518e97fb4f96f1a652f71ccdd303415a4c7bf5b573bdcbcca80428281f0dfccefc6545ea3a7f18dbb819332f34
+    prepare:
+      - |
+        tar -xzf json-c.tar.gz --strip-components=1
+
+        cmake -B build \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DBUILD_SHARED_LIBS=True \
+          -DBUILD_STATIC_LIBS=True \
+          -DCMAKE_BUILD_TYPE=None \
+         .
+    build:
+      - |
+        make -C build -j $(nproc)
+    install:
+      - |
+        make -C build DESTDIR=/rootfs install
+finalize:
+  - from: /rootfs
+    to: /

--- a/libpopt/pkg.yaml
+++ b/libpopt/pkg.yaml
@@ -1,0 +1,26 @@
+name: libpopt
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.18.tar.gz
+        destination: popt.tar.gz
+        sha256: 5159bc03a20b28ce363aa96765f37df99ea4d8850b1ece17d1e6ad5c24fdc5d1
+        sha512: 86422e8762adda3d02d46c20ac74ffe389d4f991d552b6fea729f007345b6426cbeb71160284e2deaa2ce44ce754a9e6cf6ccbd64bff9bc2253df40cdc2f79a5
+    prepare:
+      - |
+        tar -xzf popt.tar.gz --strip-components=1
+
+        ./configure \
+          --prefix=/usr
+    build:
+      - |
+        make -j $(nproc)
+    install:
+      - |
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/lvm2/patches/static-build.patch
+++ b/lvm2/patches/static-build.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/Makefile.in b/tools/Makefile.in
+index 2620daa17..3912f2d61 100644
+--- a/tools/Makefile.in
++++ b/tools/Makefile.in
+@@ -136,7 +136,7 @@ man-generator: man-generator.o
+
+ lvm.static: $(OBJECTS) lvm-static.o $(LVMINTERNAL_LIBS)
+ 	@echo "    [CC] $@"
+-	$(Q) $(CC) $(CFLAGS) $(LDFLAGS) -static -L$(interfacebuilddir) -o $@ $+ \
++	$(Q) $(CC) $(CFLAGS) $(LDFLAGS) -static -L$(top_builddir)/libdm/ioctl -o $@ $+ \
+ 	      $(DMEVENT_LIBS) $(STATIC_LIBS) $(LVMLIBS)
+
+ liblvm2cmd.a: $(top_builddir)/lib/liblvm-internal.a $(OBJECTS) lvmcmdlib.o lvm2cmd.o

--- a/lvm2/pkg.yaml
+++ b/lvm2/pkg.yaml
@@ -5,12 +5,13 @@ dependencies:
   - stage: base
   - stage: libaio
   - stage: eudev
+  - stage: util-linux
 steps:
   - sources:
-      - url: https://mirrors.kernel.org/sourceware/lvm2/LVM2.2.03.09.tgz
+      - url: https://mirrors.kernel.org/sourceware/lvm2/LVM2.2.03.10.tgz
         destination: lvm2.tar.gz
-        sha256: c03a8b8d5c03ba8ac54ebddf670ae0d086edac54a6577e8c50721a8e174eb975
-        sha512: 8540e46a6025ab14b592ccd9493b3224ffc0f962739a0a8de6d7b25c65c6ad96fc83ddb0e3d877b123a5e1b104476d0c20ccee2ead6d322257ec82ad1e3362d4
+        sha256: 5ad1645a480440892e35f31616682acba0dc204ed049635d2df3e5a5929d0ed0
+        sha512: 8678ae2f99739ccad0250f6f4b4b8e84520f2053835985a1ea9c80196a64df31a48858aebf983170c3dfcafecea83f2c6aa630ef73fd31dd84cf1627a1b421e4
     prepare:
       - |
         tar -xzf lvm2.tar.gz --strip-components=1
@@ -19,6 +20,7 @@ steps:
         patch -p0 < /pkg/patches/fix-stdio-usage.patch
         patch -p0 < /pkg/patches/mlockall-default-config.patch
         patch -p1 < /pkg/patches/disable-create_toolcontext-buffering.patch
+        patch -p1 < /pkg/patches/static-build.patch
 
         mkdir build
         cd build
@@ -38,6 +40,7 @@ steps:
              --enable-pkgconfig \
              --enable-udev_sync \
              --enable-udev_rules \
+             --enable-static_link \
              --with-udev-prefix=/usr
     build:
       - |


### PR DESCRIPTION
This adds `cryptsetup` and related utilities. We can use those to enable
raw disk encryption or LUKS-based encryption.

We could use the integrity modules as well if we need to.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>