### PR TITLE
fix: patch GRUB to allow install to loopback devices

### DIFF
--- a/grub/patches/udev.patch
+++ b/grub/patches/udev.patch
@@ -1,0 +1,77 @@
+diff --git a/grub-core/osdep/linux/hostdisk.c b/grub-core/osdep/linux/hostdisk.c
+index da62f924e..c805efb3c 100644
+--- a/grub-core/osdep/linux/hostdisk.c
++++ b/grub-core/osdep/linux/hostdisk.c
+@@ -98,52 +98,34 @@ grub_util_get_fd_size_os (grub_util_fd_t fd, const char *name, unsigned *log_sec
+ static char *
+ sysfs_partition_path (const char *dev, const char *entry)
+ {
+-  const char *argv[7];
+-  int fd;
+-  pid_t pid;
+-  FILE *udevadm;
+-  char *buf = NULL;
+-  size_t len = 0;
+   char *path = NULL;
++  char *sys_disk;
++  int is_part;
++  struct stat st;
+ 
+-  argv[0] = "udevadm";
+-  argv[1] = "info";
+-  argv[2] = "--query";
+-  argv[3] = "path";
+-  argv[4] = "--name";
+-  argv[5] = dev;
+-  argv[6] = NULL;
++  grub_util_info ("Looking for %s in sys_partition_path", dev);
+ 
+-  pid = grub_util_exec_pipe (argv, &fd);
++  if (stat(dev, &st) < 0) {
++    return 0;
++  }
+ 
+-  if (!pid)
+-    return NULL;
++  sys_disk = grub_util_part_to_disk (dev, &st, &is_part);
++  if (!sys_disk)
++    return 0;
+ 
+-  /* Parent.  Read udevadm's output.  */
+-  udevadm = fdopen (fd, "r");
+-  if (!udevadm)
+-    {
+-      grub_util_warn (_("Unable to open stream from %s: %s"),
+-		      "udevadm", strerror (errno));
+-      close (fd);
+-      goto out;
+-    }
++  grub_util_info ("got sys_disk %s, dev %s", sys_disk, dev);
+ 
+-  if (getline (&buf, &len, udevadm) > 0)
+-    {
+-      char *newline;
++  if (!is_part) {
++    free(sys_disk);
++    return 0;
++  }
+ 
+-      newline = strchr (buf, '\n');
+-      if (newline)
+-	*newline = '\0';
+-      path = xasprintf ("/sys%s/%s", buf, entry);
+-    }
+ 
+-out:
+-  if (udevadm)
+-    fclose (udevadm);
+-  waitpid (pid, NULL, 0);
+-  free (buf);
++  path = xasprintf("/sys/block/%s/%s/%s", sys_disk + 5, dev + 5, entry);
++
++  grub_util_info ("sysfs built path %s", path);
++
++  free(sys_disk);
+ 
+   return path;
+ }

--- a/grub/pkg.yaml
+++ b/grub/pkg.yaml
@@ -19,6 +19,9 @@ steps:
         tar -xJf grub.tar.xz --strip-components=1
 
         /toolchain/bin/bash ./autogen.sh
+
+        patch -p1 < /pkg/patches/udev.patch
+
     build:
       - |
         case "${ARCH}" in


### PR DESCRIPTION
GRUB has a lot of ways to find partition start for each partition it's
working on. Some of them don't work for loopback devices (GETGEO ioctl),
some don't work inside container (getting to udevd via udevadm).

As in our case partition layout is fixed, we can simplify things a lot
by simply building correct sysfs path.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>