### PR TITLE
fix: build `hwdb.bin` from hwdb files in eudev package

### DIFF
--- a/eudev/pkg.yaml
+++ b/eudev/pkg.yaml
@@ -39,6 +39,8 @@ steps:
       - |
         cd build
         make install DESTDIR=/rootfs
+
+        /rootfs/usr/bin/udevadm hwdb -r /rootfs --update
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
See e.g. http://www.linuxfromscratch.org/lfs/view/9.1/chapter06/eudev.html

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>