### PR TITLE
fix: disable hwdb in eudev

### DIFF
--- a/eudev/pkg.yaml
+++ b/eudev/pkg.yaml
@@ -30,7 +30,7 @@ steps:
           --libexecdir=/usr/libexec \
           --sbindir=/sbin \
           --disable-manpages \
-          --enable-hwdb
+          --disable-hwdb
     build:
       - |
         cd build


### PR DESCRIPTION
Hardware DB might make little sense for servers, so disable it to
reduce initramfs size.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>