### PR TITLE
feat: upgrade containerd to v1.4.0

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: libseccomp
 steps:
   - sources:
-      - url: https://github.com/containerd/containerd/archive/v1.3.6.tar.gz
+      - url: https://github.com/containerd/containerd/archive/v1.4.0.tar.gz
         destination: containerd.tar.gz
-        sha256: 82424cb6727d2f8935eec35ad41653ca62febe3665a938f4fb25704fd20ea236
-        sha512: 2d40f925a724d87a8288060037622ba24be81df2734ba08418aa33534dac9265455e1c64244880b4de82074887cd5e19442da5abb6f1f32d1a5ad42c8f082d81
+        sha256: d6284c69e1933e4c05fe285feebef461efe8cd2030634dcf1cbdcde46abe86be
+        sha512: 5ac733a0823f5b680d40f76cb5a8277e84efdd6642d15c1735049f8859bf9f87b212b4075bdc13e8f09a5564b55ce74d7d1290628b0ca92d9753ef9bfa9a0e44
     prepare:
       - |
         export GOPATH=/go
@@ -24,7 +24,7 @@ steps:
         export GOPATH=/go
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         cd ${GOPATH}/src/github.com/containerd/containerd
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 BUILDTAGS='seccomp no_btrfs' VERSION=v1.3.6 REVISION=be75852b8d7849474a20192f9ed1bf34fdd454f1
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 BUILDTAGS='seccomp no_btrfs' VERSION=v1.4.0 REVISION=09814d48d50816305a8e6c1a4ae3e2bcc4ba725a
     install:
       - |
         mkdir -p /rootfs/bin


### PR DESCRIPTION
This brings in the latest stable containerd.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
