### PR TITLE
feat: update to tools and new toolchain (incl. gcc 10.2.0)

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,4 +3,4 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: docker.io/autonomy/tools:v0.3.0-1-g66c4c43
+  TOOLS_IMAGE: docker.io/autonomy/tools:v0.3.0-3-g6b491a6

--- a/ca-certificates/pkg.yaml
+++ b/ca-certificates/pkg.yaml
@@ -1,10 +1,10 @@
 name: ca-certificates
 steps:
   - sources:
-      - url: https://curl.haxx.se/ca/cacert-2020-01-01.pem
+      - url: https://curl.haxx.se/ca/cacert-2020-07-22.pem
         destination: cacert.pem
-        sha256: adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f
-        sha512: cc129ae1a4377a43a74b0854b6eccb2b315cdfce018142d1dd5524fb64c8945cde067cb18f366351fa7d6af3f9f36cf21bc1f626f987f9e4627878472ea59cde
+        sha256: 2782f0f8e89c786f40240fc1916677be660fb8d8e25dede50c9f6f7b0c2c2178
+        sha512: 0d49bd1435a25b113a34ac38b337a9c904b6ac720824fd55d410ff6d8f6d0f637b54fd92cdff31d1c632b6a77f35fe55de9c756f35365387cea94f0fd93631b1
     install:
       - |
         mkdir -p /rootfs/etc/ssl/certs

--- a/ipmitool/patches/gcc-10.patch
+++ b/ipmitool/patches/gcc-10.patch
@@ -1,0 +1,37 @@
+From 51c7e0822f531469cf860dfa5d010c87b284b747 Mon Sep 17 00:00:00 2001
+From: Vaclav Dolezal <vdolezal@redhat.com>
+Date: Thu, 23 Jan 2020 11:26:32 +0100
+Subject: [PATCH] hpmfwupg: move variable definition to .c file
+
+Signed-off-by: Vaclav Dolezal <vdolezal@redhat.com>
+---
+ include/ipmitool/ipmi_hpmfwupg.h | 2 +-
+ lib/ipmi_hpmfwupg.c              | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/ipmitool/ipmi_hpmfwupg.h b/include/ipmitool/ipmi_hpmfwupg.h
+index de65292b..07f597be 100644
+--- a/include/ipmitool/ipmi_hpmfwupg.h
++++ b/include/ipmitool/ipmi_hpmfwupg.h
+@@ -800,7 +800,7 @@ typedef struct _VERSIONINFO {
+ 	char descString[HPMFWUPG_DESC_STRING_LENGTH + 1];
+ }VERSIONINFO, *PVERSIONINFO;
+
+-VERSIONINFO gVersionInfo[HPMFWUPG_COMPONENT_ID_MAX];
++extern VERSIONINFO gVersionInfo[HPMFWUPG_COMPONENT_ID_MAX];
+
+ #define TARGET_VER (0x01)
+ #define ROLLBACK_VER (0x02)
+diff --git a/lib/ipmi_hpmfwupg.c b/lib/ipmi_hpmfwupg.c
+index 4aa8cecd..d63d2c15 100644
+--- a/lib/ipmi_hpmfwupg.c
++++ b/lib/ipmi_hpmfwupg.c
+@@ -50,6 +50,8 @@
+
+ extern int verbose;
+
++VERSIONINFO gVersionInfo[HPMFWUPG_COMPONENT_ID_MAX];
++
+ int HpmfwupgUpgrade(struct ipmi_intf *intf, char *imageFilename,
+ 		int activate, int, int);
+ int HpmfwupgValidateImageIntegrity(struct HpmfwupgUpgradeCtx *pFwupgCtx);

--- a/ipmitool/pkg.yaml
+++ b/ipmitool/pkg.yaml
@@ -14,6 +14,8 @@ steps:
       - |
         tar -xzf ipmitool.tar.gz --strip-components=1
 
+        patch -p1 < /pkg/patches/gcc-10.patch
+
         mkdir build
         cd build
 

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: "{{ .TOOLS_IMAGE }}"
 steps:
   - sources:
-      - url: https://www.musl-libc.org/releases/musl-1.2.0.tar.gz
+      - url: https://www.musl-libc.org/releases/musl-1.2.1.tar.gz
         destination: musl.tar.gz
-        sha256: c6de7b191139142d3f9a7b5b702c9cae1b5ee6e7f57e582da9328629408fd4e8
-        sha512: 58bd88189a6002356728cea1c6f6605a893fe54f7687595879add4eab283c8692c3b031eb9457ad00d1edd082cfe62fcc0eb5eb1d3bf4f1d749c0efa2a95fec1
+        sha256: 68af6e18539f646f9c41a3a2bb25be4a5cfa5a8f65f0bb647fd2bbfdf877e84b
+        sha512: 455464ef47108a78457291bda2b1ea574987a1787f6001e9376956f20521593a4816bc215dab41c1a80292ae7ebd315accb4d4fa6a1210ff77d9a4d68239e960
     prepare:
       - |
         export PATH=${TOOLCHAIN}/cross/bin:${PATH}


### PR DESCRIPTION
Also bump libmuslc to 1.2.1 (matches toolchain), fix gcc 10 build error
in ipmitool, and update ca-certificates to latest.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>