### PR TITLE
chore: bump tools for Make 4.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,4 +3,4 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: docker.io/autonomy/tools:v0.3.0-3-g6b491a6
+  TOOLS_IMAGE: docker.io/autonomy/tools:v0.3.0-4-gfb8cfaa


### PR DESCRIPTION
This should speed up parallel builds on Linux 5.6+ kernels.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>