### PR TITLE
fix: use proper kernel image on arm64 for EFI stub

### DIFF
--- a/kernel/kernel/pkg.yaml
+++ b/kernel/kernel/pkg.yaml
@@ -25,7 +25,7 @@ steps:
                 mv vmlinux /rootfs/boot/vmlinux
             ;;
             arm64)
-                mv arch/arm64/boot/Image.gz /rootfs/boot/vmlinuz
+                mv arch/arm64/boot/Image /rootfs/boot/vmlinuz
                 mv vmlinux /rootfs/boot/vmlinux
             ;;
             *)


### PR DESCRIPTION
See https://www.kernel.org/doc/Documentation/efi-stub.txt

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>