### PR TITLE
fix: create dtb directory for all architectures

### DIFF
--- a/kernel/kernel/pkg.yaml
+++ b/kernel/kernel/pkg.yaml
@@ -25,6 +25,7 @@ steps:
     install:
       - |
         mkdir -p /rootfs/boot
+        mkdir -p /rootfs/dtb
         case $ARCH in
             x86_64)
                 mv arch/x86/boot/bzImage /rootfs/boot/vmlinuz
@@ -33,7 +34,6 @@ steps:
             arm64)
                 mv arch/arm64/boot/Image /rootfs/boot/vmlinuz
                 mv vmlinux /rootfs/boot/vmlinux
-                mkdir /rootfs/dtb
                 cd ./arch/arm64/boot/dts
                 for vendor in $(find . -not -path . -type d); do
                   dest="/rootfs/dtb/$vendor"


### PR DESCRIPTION
We need the `dtb` directory to exist so that it can be copied from in a
`Dockerfile`.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
