### PR TITLE
fix: build "empty" images for arm64 packages on amd64

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,6 @@ steps:
       DOCKER_CLI_EXPERIMENTAL: enabled
     commands:
       - make
-      - make arm64
     when:
       event:
         include:
@@ -56,7 +55,6 @@ steps:
     commands:
       - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
       - make PUSH=true
-      - make arm64 PUSH=true
     when:
       event:
         exclude:

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,9 @@ COMMON_ARGS += --platform=$(PLATFORM)
 empty :=
 space = $(empty) $(empty)
 
-TARGETS =  ca-certificates  cni  containerd cryptsetup dosfstools  eudev  fhs  grub ipmitool  iptables  kernel  kmod  libaio  libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns  runc  socat  syslinux  util-linux  xfsprogs
+TARGETS =  ca-certificates  cni  containerd cryptsetup dosfstools  eudev  fhs  grub ipmitool  iptables  kernel  kmod  libaio  libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns raspberrypi-firmware runc  socat  syslinux u-boot  util-linux  xfsprogs
 
 all: $(TARGETS) ## Builds all known pkgs.
-
-arm64:
-	$(MAKE) TARGETS="u-boot raspberrypi-firmware" PLATFORM=linux/arm64
 
 .PHONY: help
 help: ## This help menu.

--- a/raspberrypi-firmware/pkg.yaml
+++ b/raspberrypi-firmware/pkg.yaml
@@ -1,6 +1,7 @@
 name: raspberrypi-firmware
 variant: scratch
 shell: /toolchain/bin/bash
+# {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr restricting build to arm64 only
 dependencies:
   - stage: base
 steps:
@@ -20,3 +21,4 @@ steps:
 finalize:
   - from: /rootfs
     to: /
+# {{ end }}

--- a/u-boot/pkg.yaml
+++ b/u-boot/pkg.yaml
@@ -10,6 +10,7 @@
 name: u-boot
 variant: scratch
 shell: /toolchain/bin/bash
+# {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr restricting build to arm64 only
 dependencies:
   - stage: base
 steps:
@@ -117,3 +118,4 @@ steps:
 finalize:
   - from: /rootfs
     to: /
+# {{ end }}


### PR DESCRIPTION
If we build arm64-only versions, they're pulled into the amd64 build of
Talos as well (as there's no amd64 counterpart).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>