### PR TITLE
feat: enable CONFIG_USB_ACM

### DIFF
--- a/kernel/kernel/config-amd64
+++ b/kernel/kernel/config-amd64
@@ -4052,7 +4052,7 @@ CONFIG_USB_EHCI_PCI=y
 #
 # USB Device Class drivers
 #
-# CONFIG_USB_ACM is not set
+CONFIG_USB_ACM=y
 # CONFIG_USB_PRINTER is not set
 # CONFIG_USB_WDM is not set
 # CONFIG_USB_TMC is not set


### PR DESCRIPTION
Builds the `cdc-acm` module into the kernel.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
