### PR TITLE
chore: drop vmlinux from kernel package

### DIFF
--- a/kernel/kernel/pkg.yaml
+++ b/kernel/kernel/pkg.yaml
@@ -32,11 +32,9 @@ steps:
         case $ARCH in
             x86_64)
                 mv arch/x86/boot/bzImage /rootfs/boot/vmlinuz
-                mv vmlinux /rootfs/boot/vmlinux
             ;;
             arm64)
                 mv arch/arm64/boot/Image /rootfs/boot/vmlinuz
-                mv vmlinux /rootfs/boot/vmlinux
                 cd ./arch/arm64/boot/dts
                 for vendor in $(find . -not -path . -type d); do
                   dest="/rootfs/dtb/$vendor"


### PR DESCRIPTION
We're not using uncompressed kernel anywhere, it's huge and it can't be
used directly in most of the cases.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>