### PR TITLE
feat: enable hyperv_utils in linux kernel

### DIFF
--- a/kernel/kernel/config-amd64
+++ b/kernel/kernel/config-amd64
@@ -4463,7 +4463,7 @@ CONFIG_VHOST_VSOCK=y
 #
 CONFIG_HYPERV=y
 CONFIG_HYPERV_TIMER=y
-# CONFIG_HYPERV_UTILS is not set
+CONFIG_HYPERV_UTILS=y
 # CONFIG_HYPERV_BALLOON is not set
 # end of Microsoft Hyper-V guest support
 


### PR DESCRIPTION
CONFIG_HYPERV_UTILS=y in the amd64 kernel config

Enabling this in the kernel makes running it on Hyper-V work better:

It enables running a hyper-v integration daemon, which is needed to enable things like setting a static IP address, copying files onto the server from the virtual machine manager.

To my surprise, it also means the wallclock time gets set correctly (as opposed to shifted by an hour because we're in GMT+1), so I guess it enables automatic time sync to the hyper-v host.