### PR TITLE
feat: update Linux to 5.10.17, disable init_on_free=1 by default

### DIFF
--- a/kernel/kernel-prepare/pkg.yaml
+++ b/kernel/kernel-prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.14.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.17.tar.xz
         destination: linux.tar.xz
-        sha256: fa27b79f198b5be969e497ed5461860df48e0591c85e60699fc8be26837a1d2a
-        sha512: 8e5016bfc7f5c090af6247ddac41cb3f811576bd078b2e145d798be6f214f72ee77bbff09d48d54a0154a9b137166650c88a1d178d50d5901dcaa03bb2c5e6f1
+        sha256: e84e623ce8bb2446ec026b62eafa3b18480aa6fb6ae9c86cd8f18651324d4814
+        sha512: 2d8700ceee0c027597415de2b9fa478a651c6f5074b68d60609a4c46398ac5a854f9323fc07b187caca5294759bf99832d7496c4f4cca222240b07435b27bd60
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:

--- a/kernel/kernel/config-amd64
+++ b/kernel/kernel/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.10.14 Kernel Configuration
+# Linux/x86 5.10.17 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 10.2.0"
 CONFIG_CC_IS_GCC=y
@@ -5058,7 +5058,7 @@ CONFIG_STACKLEAK_TRACK_MIN_SIZE=100
 # CONFIG_STACKLEAK_METRICS is not set
 # CONFIG_STACKLEAK_RUNTIME_DISABLE is not set
 CONFIG_INIT_ON_ALLOC_DEFAULT_ON=y
-CONFIG_INIT_ON_FREE_DEFAULT_ON=y
+# CONFIG_INIT_ON_FREE_DEFAULT_ON is not set
 # end of Memory initialization
 # end of Kernel hardening options
 # end of Security options

--- a/kernel/kernel/config-arm64
+++ b/kernel/kernel/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.14 Kernel Configuration
+# Linux/arm64 5.10.17 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 10.2.0"
 CONFIG_CC_IS_GCC=y
@@ -7596,7 +7596,7 @@ CONFIG_STACKLEAK_TRACK_MIN_SIZE=100
 # CONFIG_STACKLEAK_METRICS is not set
 # CONFIG_STACKLEAK_RUNTIME_DISABLE is not set
 CONFIG_INIT_ON_ALLOC_DEFAULT_ON=y
-CONFIG_INIT_ON_FREE_DEFAULT_ON=y
+# CONFIG_INIT_ON_FREE_DEFAULT_ON is not set
 # end of Memory initialization
 # end of Kernel hardening options
 # end of Security options

--- a/kernel/kernel/scripts/filter-hardened-check.py
+++ b/kernel/kernel/scripts/filter-hardened-check.py
@@ -17,6 +17,7 @@ IGNORE_VIOLATIONS = {
     'CONFIG_MODULES', # enabled for backwards compat, modules require signing key which is thrown away
     'CONFIG_IA32_EMULATION', # see https://github.com/talos-systems/pkgs/pull/125
     'CONFIG_HARDEN_BRANCH_PREDICTOR', # looks like a bug in kconfig-hardened-check, default in 5.9, but not enabled in 5.10
+    'CONFIG_INIT_ON_FREE_DEFAULT_ON', # disabled init_on_free=1 due to performance
 }
 
 def main():


### PR DESCRIPTION
KSPP doesn't strictly require init_on_free=1:

```
The init_on_free is only needed if there is concern about minimizing stale data lifetime.
```

It has significant performance impact:

```
Slowdown for the new features compared to init_on_free=0,
init_on_alloc=0:

hackbench, init_on_free=1:  +7.62% sys time (st.err 0.74%)
hackbench, init_on_alloc=1: +7.75% sys time (st.err 2.14%)

Linux build with -j12, init_on_free=1:  +8.38% wall time (st.err 0.39%)
Linux build with -j12, init_on_free=1:  +24.42% sys time (st.err 0.52%)
Linux build with -j12, init_on_alloc=1: -0.13% wall time (st.err 0.42%)
Linux build with -j12, init_on_alloc=1: +0.57% sys time (st.err 0.40%)
```

And it causes all the RAM to be allocated (touched) on boot which causes
problems with virtualized environments in memory over-commit scenarios.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>