### PR TITLE
feat: upgrade u-boot to 2021.04-rc3

### DIFF
--- a/u-boot/pkg.yaml
+++ b/u-boot/pkg.yaml
@@ -19,10 +19,10 @@ steps:
         destination: arm-trusted-firmware.tar.gz
         sha256: 4bfda9fdbe5022f2e88ad3344165f7d38a8ae4a0e2d91d44d9a1603425cc642d
         sha512: 99c5b73345e605db70941a0d44cfe3a1d3df8bbc615e4f2602ca90055cc7150a205350d9ae73dec73fcee85e6877351136428f996d421e57147c931a36f6a330
-      - url: https://ftp.denx.de/pub/u-boot/u-boot-2021.01.tar.bz2
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-2021.04-rc3.tar.bz2
         destination: u-boot.tar.bz2
-        sha256: b407e1510a74e863b8b5cb42a24625344f0e0c2fc7582d8c866bd899367d0454
-        sha512: 40dd4d9ef87a1829158658c433d46a047a39c0d8c314ad8d133f7240343ee3a75b060f009dd2efe598cfb8a766773f6cd773ea7f7745ee88e52a771c77eb1c6e
+        sha256: 7c418e07f6065c8761eb2df890bb524d7109864325d8850ddb0c93eb345734f9
+        sha512: 0d6b46b791475ce21320fbc2b361235d09588a5b912d40b32a11d937adc7c0e7b75b893ba4e8dc55156cfd99f684fc56839c17d0b9c021f5cfaaf5e5997f93ba
     env:
       SUN50I_A64_ARM_TRUSTED_FIRMWARE: sun50i_a64_arm-trusted-firmware
       RK3328_ARM_TRUSTED_FIRMWARE: rk3328_arm-trusted-firmware


### PR DESCRIPTION
This PR pulls in an RC of u-boot that contains the fixes necessary to
get USB support on rpi to work properly.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>