### PR TITLE
chore: do not use git-lfs for rockpi4 binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.bin filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Looks like an overkill for such a small files, while it brings issues
in our CI pipeline as you have to install git-lfs there.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>