### PR TITLE
chore: update tools tag to v0.5.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.5.0-alpha.0-4-g1f26def
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.5.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
No changes, just image tag update.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>