### PR TITLE
fix: build `zbin` utility for both amd64 and arm64

### DIFF
--- a/ipxe/pkg.yaml
+++ b/ipxe/pkg.yaml
@@ -21,6 +21,7 @@ steps:
 
         {{ if eq .ARCH "aarch64" }}
         ARCH= make -j $(nproc) bin-arm64-efi/ipxe.efi EMBED=/pkg/files/ipxe.script
+        gcc ./util/zbin.c -llzma -o util/zbin
         {{ else }}
         ARCH= make -j $(nproc) bin/undionly.kpxe bin-x86_64-efi/ipxe.efi EMBED=/pkg/files/ipxe.script
         ARCH= make bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo EMBED=/pkg/files/ipxe.script
@@ -29,14 +30,15 @@ steps:
       - |
         cd src/
 
-        mkdir -p /rootfs/{usr/libexec,usr/libexec/zbin}
+        mkdir -p /rootfs/{usr/libexec,usr/libexec/kpxe}
 
         {{ if eq .ARCH "aarch64" }}
         cp -p bin-arm64-efi/ipxe.efi /rootfs/usr/libexec
         {{ else }}
         cp -p bin/undionly.kpxe bin-x86_64-efi/ipxe.efi /rootfs/usr/libexec
-        cp -p bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo util/zbin /rootfs/usr/libexec/zbin
+        cp -p bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo /rootfs/usr/libexec/kpxe
         {{ end }}
+        cp -p util/zbin /rootfs/usr/libexec
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
Utility `zbin` is used to compress `undionly.kpxe` image for x86, but if
the Sidero is running on `arm64`, we still need utility `zbin` for
arm64. Regular build depends on x86, so just extract build as a single
invocation of `gcc`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>