### PR TITLE
feat: update containerd to 1.4.5, runc to 1.0.0-rc94

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: libseccomp
 steps:
   - sources:
-      - url: https://github.com/containerd/containerd/archive/v1.4.4.tar.gz
+      - url: https://github.com/containerd/containerd/archive/v1.4.5.tar.gz
         destination: containerd.tar.gz
-        sha256: ac62c64664bf62fd44df0891c896eecdb6d93def3438271d7892dca75bc069d1
-        sha512: f09930d19f53381d86cf522954458ecc949f15a0c6a49f990bdb61fe19afee075356338998ed84bd756f16ba85211f55f9c638de8b7083d71e24d8e87335e070
+        sha256: 63da3af809328cd90d3c1544126d30910a9ea9d45ac5eac751cf39d736514eab
+        sha512: 2df2e8a08ffc9134bb0fe143bdcd64a4c8bed2fe9d72263da8d9389daff3ed801eec2e5b31caffac1e6245386b8843a5022c456c60c0dcedbaae3d7b74ecb048
     env:
       GO111MODULE: off
     prepare:
@@ -26,7 +26,7 @@ steps:
         export GOPATH=/go
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         cd ${GOPATH}/src/github.com/containerd/containerd
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 BUILDTAGS='seccomp no_btrfs' VERSION=v1.4.4 REVISION=05f951a3781f4f2c1911b05e61c160e9c30eaa8e
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 BUILDTAGS='seccomp no_btrfs' VERSION=v1.4.5 REVISION=8263eb3eaee447b16856eeb8839d5df4c9cca71a
     install:
       - |
         mkdir -p /rootfs/bin

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
   - stage: libseccomp
 steps:
   - sources:
-      - url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.tar.xz
+      - url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc94/runc.tar.xz
         destination: runc.tar.xz
-        sha256: 2f76b623b550588db98e2be72e74aae426f5d4cf736bd92afb91dd5586816daf
-        sha512: 55d28e07e645bf07d104281e3e80c3df9a53e23342d281a135e8792eb8e8b6b35477dd0ce367032a7f698c4ac939dc7dfcfbffb69cdc7532dd149ff44c5db251
+        sha256: 87daf369dcac7f1895e72bc0ee22ba9e29d4678d6d0dd795f336e35c222a801a
+        sha512: a1ce2a5ae21f0d4ac1b2d26cbf0ef60e119dfffb984c5fdec1e46f55a2bdcf64ed743b52837ed105932b935a60739e62d9b1af2ddd9e4f16ee5c1b81e4f7e360
     prepare:
       - |
         export GOPATH=/go
@@ -26,7 +26,7 @@ steps:
         export CC=/toolchain/bin/cc
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
-        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=ff819c7e9184c13b7c2607fe6c30ae19403a7aff runc
+        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=2c7861bc5e1b3e756392236553ec14a78a09f8bf runc
     install:
       - |
         export GOPATH=/go


### PR DESCRIPTION
This is a direct update in release-0.5 branch (for Talos 0.10), as
master is already at containerd 1.5.0.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>