### PR TITLE
chore: bump tools to final release 0.6.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.5.0-1-gc8c2a18
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.6.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
This should match upcoming Talos 0.11 release.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>