### PR TITLE
chore: bump tools to 0.7.0-alpha.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.5.0-1-gc8c2a18
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.7.0-alpha.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
This is master version for Talos 0.12

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>