### PR TITLE
feat: update containerd and runc versions

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -6,10 +6,11 @@ dependencies:
   - stage: libseccomp
 steps:
   - sources:
-      - url: https://github.com/containerd/containerd/archive/v1.5.2.tar.gz
+        # sync with version and revision in build
+      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.5.5.tar.gz
         destination: containerd.tar.gz
-        sha256: d72a85cbcd60009f41637e97e37a372a2451b369c183e2b58fdab00e1c9fe894
-        sha512: e4f03e77f2d8f823680629efc8cf41db70a656edf46807dca69652e6500dc51b0ceb0fd174768a8a5069c8af3e78853c20d214d135e36d4f3559399894e2cdf1
+        sha256: 7a04c284066882152e4968c4997b7a0b1c85c0ba549dad66f3911864163646dd
+        sha512: 8ee5aa1d35e76238fd8707bff6b7eedb7931e6489d49b6907a8e190b076fe6fd95ae5e85ecea1605adb7fcd4f3ae0e926696f1d2f3c0d12b61e6df906929b9eb
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
@@ -20,7 +21,8 @@ steps:
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 BUILDTAGS='seccomp no_btrfs' VERSION=v1.5.2 REVISION=36cc874494a56a253cd181a1a685b44b58a2e34a
+        export BUILDTAGS='seccomp no_aufs no_btrfs no_devmapper no_zfs'
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.5.5 REVISION=72cec4be58a9eb6b2910f5d10f1c01ca47d231c0
     install:
       - |
         mkdir -p /rootfs/bin

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -6,10 +6,11 @@ dependencies:
   - stage: libseccomp
 steps:
   - sources:
-      - url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.tar.xz
+      # sync with commit in build
+      - url: https://github.com/opencontainers/runc/releases/download/v1.0.1/runc.tar.xz
         destination: runc.tar.xz
-        sha256: 8304b161e1c0ec2cee969b25671a147cd56cb99e6aa534371b2cfb3ec13db2c4
-        sha512: e2f30a4da4a56b1e017a2c3d0dc2df4b719e118f91ba051b29bca5e5cd9c99a07aa0da35c86a1f5748ea1392c951e33bfb4c55d2aef46264dfabf134d7f27e12
+        sha256: 7401a8be2556490074418c4b04c6e0584854ff15e899da9ebeb6d22abd877323
+        sha512: 1db35ec91ab59b7bc3c863231e0f610000526859df2a792675fbe5917ade18e2c5df26a613897f0cefa90ba4d4f590e55ec6df84958a44384379e693f9b65b10
     prepare:
       - |
         export GOPATH=/go
@@ -26,7 +27,7 @@ steps:
         export CC=/toolchain/bin/cc
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
-        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7 runc
+        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=4144b63817ebcc5b358fc2c8ef95f7cddd709aa7 runc
     install:
       - |
         export GOPATH=/go


### PR DESCRIPTION
This pulls current definitions from master:

* containerd 1.5.5
* runc 1.0.1

This addresses security vulnerability
[CVE-2021-32760](https://github.com/containerd/containerd/security/advisories/GHSA-c72p-9xmj-rx3w).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>