### PR TITLE
chore: patch grub with support for reproducible ISO builds

### DIFF
--- a/grub/patches/efi-fat-serial-number.patch
+++ b/grub/patches/efi-fat-serial-number.patch
@@ -1,0 +1,30 @@
+Change 'grub-mkrescue' to honor the 'GRUB_FAT_SERIAL_NUMBER'
+environment variable.  That way, the caller can specify a fixed
+serial number (instead of the randomly chosen one) to create EFI
+images (the 'efi.img' file) that are reproducible bit-for-bit.
+
+Patch by Ludovic Courtès <ludo@gnu.org>.
+Mangled (for GRUB 2.04) by Tobias Geerinckx-Rice <me@tobias.gr>.
+
+From https://github.com/guix-mirror/guix/blob/master/gnu/packages/patches/grub-efi-fat-serial-number.patch
+
+--- grub-2.04/util/grub-mkrescue.c	2019-05-20 13:01:11.000000000 +0200
++++ grub-2.04/util/grub-mkrescue.c	2019-07-08 23:57:36.912104652 +0200
+@@ -809,8 +809,15 @@
+       free (efidir_efi_boot);
+
+       efiimgfat = grub_util_path_concat (2, iso9660_dir, "efi.img");
+-      rv = grub_util_exec ((const char * []) { "mformat", "-C", "-f", "2880", "-L", "16", "-i",
+-	    efiimgfat, "::", NULL });
++
++      const char *fat_serial_number = getenv ("GRUB_FAT_SERIAL_NUMBER");
++      const char *mformat_args[] =
++       { "mformat", "-C", "-f", "2880", "-L", "16",
++         fat_serial_number != NULL ? "-N" : "-C",
++         fat_serial_number != NULL ? fat_serial_number : "-C",
++         "-i", efiimgfat, "::", NULL };
++
++      rv = grub_util_exec (mformat_args);
+       if (rv != 0)
+ 	grub_util_error ("`%s` invocation failed\n", "mformat");
+       rv = grub_util_exec ((const char * []) { "mcopy", "-s", "-i", efiimgfat, efidir_efi, "::/", NULL });

--- a/grub/pkg.yaml
+++ b/grub/pkg.yaml
@@ -21,6 +21,7 @@ steps:
         /toolchain/bin/bash ./autogen.sh
 
         patch -p1 < /pkg/patches/udev.patch
+        patch -p1 < /pkg/patches/efi-fat-serial-number.patch
 
     build:
       - |


### PR DESCRIPTION
This adds a patch to force FAT serial number for the EFI partition.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>