### PR TITLE
chore: bump tools for Go 1.16.7

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.7.0-alpha.0-2-g7172a5d
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.7.0-alpha.0-3-g2368154
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
See https://github.com/talos-systems/tools/pull/144

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>