### PR TITLE
chore: support builds with HTTP_PROXY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ PUSH ?= false
 COMMON_ARGS := --file=Pkgfile
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
+COMMON_ARGS += --build-arg=http_proxy=$(http_proxy)
+COMMON_ARGS += --build-arg=https_proxy=$(https_proxy)
 
 , := ,
 empty :=

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.5-frontend
+# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.6-frontend
 
 format: v1alpha2
 


### PR DESCRIPTION
This pulls in bldr with support HTTP_PROXY and also pushes http_proxy
environment variables to the build environment.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>