### PR TITLE
chore: update tools

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0-alpha.0-2-g5b9d214
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0-alpha.0-3-g2790b55
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
To use Go 1.17.1.
