### PR TITLE
backport: feat: update containerd to 1.5.6, runc to 1.0.2, libseccomp to 2.5.2

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
 steps:
   - sources:
         # sync with version and revision in build
-      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.5.5.tar.gz
+      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.5.6.tar.gz
         destination: containerd.tar.gz
-        sha256: 7a04c284066882152e4968c4997b7a0b1c85c0ba549dad66f3911864163646dd
-        sha512: 8ee5aa1d35e76238fd8707bff6b7eedb7931e6489d49b6907a8e190b076fe6fd95ae5e85ecea1605adb7fcd4f3ae0e926696f1d2f3c0d12b61e6df906929b9eb
+        sha256: 144612f9400c2fc52b2abc7b1ef33bf708d322dad9b3afdc1ae9d02fa034753b
+        sha512: 5898bd13baec52730acaab4f9091c0fb64e4f8e5fe8d96cc1fc31f082bb876fccb862164c0e2d82e13a4dac959f6040aa6c9d01ca7671a2b75d0d384f84b86ef
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
@@ -22,7 +22,7 @@ steps:
         export CGO_ENABLED=1
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         export BUILDTAGS='seccomp no_aufs no_btrfs no_devmapper no_zfs'
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.5.5 REVISION=72cec4be58a9eb6b2910f5d10f1c01ca47d231c0
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.5.6 REVISION=1a1b383ad5b520349f13f9715e0cd1e2f132c087
     install:
       - |
         mkdir -p /rootfs/bin

--- a/kernel/kernel/scripts/filter-hardened-check.py
+++ b/kernel/kernel/scripts/filter-hardened-check.py
@@ -18,6 +18,8 @@ IGNORE_VIOLATIONS = {
     'CONFIG_IA32_EMULATION', # see https://github.com/talos-systems/pkgs/pull/125
     'CONFIG_HARDEN_BRANCH_PREDICTOR', # looks like a bug in kconfig-hardened-check, default in 5.9, but not enabled in 5.10
     'CONFIG_INIT_ON_FREE_DEFAULT_ON', # disabled init_on_free=1 due to performance
+    'CONFIG_ARM64_EPAN', # not available in 5.10, first introduced in 5.13
+    'CONFIG_RANDOMIZE_KSTACK_OFFSET_DEFAULT', # not available in 5.10, first introduced in 5.13
 }
 
 def main():

--- a/libseccomp/pkg.yaml
+++ b/libseccomp/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/seccomp/libseccomp/releases/download/v2.5.1/libseccomp-2.5.1.tar.gz
+      - url: https://github.com/seccomp/libseccomp/releases/download/v2.5.2/libseccomp-2.5.2.tar.gz
         destination: libseccomp.tar.gz
-        sha256: ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55
-        sha512: 2be80a6323f9282dbeae8791724e5778b32e2382b2a3d1b0f77366371ec4072ea28128204f675cce101c091c0420d12c497e1a9ccbb7dc5bcbf61bfd777160af
+        sha256: 17a652dfb491d96be893960e9b791914936ee16c13b777a3caf562fe48cb87df
+        sha512: b2a95152cb274d6b35753596fd825406dae20c4a48b2f4076f835f977ecf324de38a3fe02e789dc20b49ecf6b4eb67f03e7733e92d40f5e20f25874307f1c2ac
     prepare:
       - |
         tar -xzf libseccomp.tar.gz --strip-components=1

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
 steps:
   - sources:
       # sync with commit in build
-      - url: https://github.com/opencontainers/runc/releases/download/v1.0.1/runc.tar.xz
+      - url: https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.tar.xz
         destination: runc.tar.xz
-        sha256: 7401a8be2556490074418c4b04c6e0584854ff15e899da9ebeb6d22abd877323
-        sha512: 1db35ec91ab59b7bc3c863231e0f610000526859df2a792675fbe5917ade18e2c5df26a613897f0cefa90ba4d4f590e55ec6df84958a44384379e693f9b65b10
+        sha256: 740acb49e33eaf4958b5109c85363c1d3900f242d4cab47fbdbefa6f8f3c6909
+        sha512: 2feae69e7680c55de4dc9bb7d77e8275b47b58f5549b061bd6ceef493cb16a5505e0077cf36fea4b0ec799327143aa9f5f46572d55007270ac93fa87aaadd530
     prepare:
       - |
         export GOPATH=/go
@@ -27,7 +27,7 @@ steps:
         export CC=/toolchain/bin/cc
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
-        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=4144b63817ebcc5b358fc2c8ef95f7cddd709aa7 runc
+        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=52b36a2dd837e8462de8e01458bf02cf9eea47dd runc
     install:
       - |
         export GOPATH=/go


### PR DESCRIPTION
Update container runtime components.

Containerd release contains a fix for CRI plugin config merge.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit f22ce181d8dae3481a011772e92029d6ef351cc5)

(backporting for Talos 0.12.x)