### PR TITLE
chore: update tools to tagged version 0.8.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0-alpha.0-3-g2790b55
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
Getting things updated for Talos 0.13.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>