### PR TITLE
feat: update libseccomp to 2.5.3

### DIFF
--- a/libseccomp/pkg.yaml
+++ b/libseccomp/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/seccomp/libseccomp/releases/download/v2.5.2/libseccomp-2.5.2.tar.gz
+      - url: https://github.com/seccomp/libseccomp/releases/download/v2.5.3/libseccomp-2.5.3.tar.gz
         destination: libseccomp.tar.gz
-        sha256: 17a652dfb491d96be893960e9b791914936ee16c13b777a3caf562fe48cb87df
-        sha512: b2a95152cb274d6b35753596fd825406dae20c4a48b2f4076f835f977ecf324de38a3fe02e789dc20b49ecf6b4eb67f03e7733e92d40f5e20f25874307f1c2ac
+        sha256: 59065c8733364725e9721ba48c3a99bbc52af921daf48df4b1e012fbc7b10a76
+        sha512: 00170fe2360f0c0b33293dccfcc33e98fabb99619f34ecefbcc92bfdaa249ba91e7433226545b842b71542a3b224b6e980ea2ae656c4addf07e84a0def1870a0
     prepare:
       - |
         tar -xzf libseccomp.tar.gz --strip-components=1


### PR DESCRIPTION
To use the same version as tools.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@talos-systems.com>