### PR TITLE
feat: bump raspberrypi-firmware to 1.20211029

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -6,7 +6,10 @@ policies:
 - type: commit
   spec:
     dco: true
-    gpg: false
+    gpg:
+      required: true
+      identity:
+        gitHubOrganization: talos-systems
     spellcheck:
       locale: US
     maximumOfOneCommit: true

--- a/raspberrypi-firmware/pkg.yaml
+++ b/raspberrypi-firmware/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
 steps:
 # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr restricting build to arm64 only
   - sources:
-      - url: https://github.com/raspberrypi/firmware/archive/1.20210805.tar.gz
+      - url: https://github.com/raspberrypi/firmware/archive/refs/tags/1.20211029.tar.gz
         destination: raspberrypi-firmware.tar.gz
-        sha256: b7feefd3a477787228b82df72dce52e6b91c1a37da6795779c0473bc78b20419
-        sha512: 522f3ca12f6d168066358950da5a3e03697ef526958727ec68ddd8259e68e84c10fbbc29ca151b1e7b14ef0ec0dcd5b0f69149635b56af4abf0dfc23a9406ccf
+        sha256: 22d0d5d2df73263bd0e6bdcd31c7e0d97ea6c438834e2cfaa51cb958f20b7205
+        sha512: 7a1fe3b1645006c35fa49e842b9ece53b386ece42b8db99649de8d4bc0c19e34b0807767290e26422528606c5847843533aaa0edd0716e9f9f9dcae340a4dce0
     prepare:
       - |
         tar -xzf raspberrypi-firmware.tar.gz --strip-components=1


### PR DESCRIPTION
in order to be able to enable `arm_boost`. arm_boost will add 300Mhz to the clockspeed of newer broadcom CPUs