### PR TITLE
feat: update CNI to 1.0.1, separate package for flannel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COMMON_ARGS += --build-arg=https_proxy=$(https_proxy)
 empty :=
 space = $(empty) $(empty)
 
-TARGETS =  ca-certificates  cni  containerd cryptsetup dosfstools  eudev  fhs  grub ipmitool  iptables ipxe kernel  kmod  libaio libjson-c liblzma libpopt libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns raspberrypi-firmware runc  socat  syslinux u-boot  util-linux  xfsprogs
+TARGETS =  ca-certificates  cni  containerd cryptsetup dosfstools  eudev  fhs flannel-cni grub ipmitool  iptables ipxe kernel  kmod  libaio libjson-c liblzma libpopt libressl  libseccomp  linux-firmware lvm2  musl  open-iscsi  open-isns raspberrypi-firmware runc  socat  syslinux u-boot  util-linux  xfsprogs
 
 all: $(TARGETS) ## Builds all known pkgs.
 

--- a/ca-certificates/pkg.yaml
+++ b/ca-certificates/pkg.yaml
@@ -1,10 +1,10 @@
 name: ca-certificates
 steps:
   - sources:
-      - url: https://curl.haxx.se/ca/cacert-2021-07-05.pem
+      - url: https://curl.se/ca/cacert-2021-10-26.pem
         destination: cacert.pem
-        sha256: a3b534269c6974631db35f952e8d7c7dbf3d81ab329a232df575c2661de1214a
-        sha512: 881183c7fed512cab763a6145f0e07c5bcdc143589baf433f7ba92223d215f18f48782fcfc04860db0671849e2ceeecedf6704f77148f588e17c4cd9a34cc8f8
+        sha256: ae31ecb3c6e9ff3154cb7a55f017090448f88482f0e94ac927c0c67a1f33b9cf
+        sha512: bcc17f23eb54f943c13c6e8b3b0a7e8b72dc9971720249b3eb7a493a66db21d572ba7eedf4f96d8efd6243c3e89f3e258e59ebc9010bce01556b4112ec7d4a3b
     install:
       - |
         mkdir -p /rootfs/etc/ssl/certs

--- a/cni/pkg.yaml
+++ b/cni/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/containernetworking/plugins/archive/refs/tags/v0.9.1.tar.gz
+      - url: https://github.com/containernetworking/plugins/archive/refs/tags/v1.0.1.tar.gz
         destination: cni-plugins.tar.gz
-        sha256: 35e96c6c47b9d080d1cbdcfca02808b01a95464607cd2a2c971b3ad596285928
-        sha512: 24e8fcedbff2ae7a83aa96085b546b164de6a0884d593e3b5386e9d2de3c4d9a215db9e9405332020cc45c371709a32b600e263e4f8dee62c51adafdc0180f24
+        sha256: 2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619
+        sha512: 01edfb3d3c9cf34da7c97a255c9396d49b2b73a11352526d4dd7dfaa0b63e93b09261aa5f68a36f3dcf3d31c0ffd48070717abcd8a65ddb563e3402350f20352
     env:
       GOPATH: /go
     prepare:

--- a/flannel-cni/pkg.yaml
+++ b/flannel-cni/pkg.yaml
@@ -1,0 +1,47 @@
+name: flannel-cni
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://github.com/flannel-io/cni-plugin/archive/refs/tags/v1.0.0.tar.gz
+        destination: flannel-cni.tar.gz
+        sha256: b7657d40ed28749c26c81df5c95015b9811bee853a08b9becaf7df718ebeed14
+        sha512: 4b75cfe2af334b974093e520657a92f69e2d20b43319d8425d7f024aef0ed5b923908a55fe146a561a5e3e83be9fda218e4317b29d9e58c2f414402c58f0fea6
+    env:
+      GOPATH: /go
+    prepare:
+      - |
+        mkdir -p ${GOPATH}/src/
+        tar -xzf flannel-cni.tar.gz --strip-components=1 -C ${GOPATH}/src/
+
+        mkdir -p /etc/ssl/certs/
+        ln -s /toolchain/etc/ssl/certs/ca-certificates /etc/ssl/certs/ca-certificates
+    build:
+      - |
+        export PATH=${PATH}:${TOOLCHAIN}/go/bin
+        cd ${GOPATH}/src/
+
+        export GOARCH=$(go env GOARCH)
+        export VERSION=v1.0.0
+        export TAG=${VERSION}
+
+        {{ if eq .ARCH "x86_64" }}
+        export CGO_ENABLED=1
+        {{ end }}
+
+        go mod vendor
+
+        /toolchain/bin/bash scripts/build_flannel.sh
+    install:
+      - |
+        mkdir -p /rootfs/opt/cni/bin
+
+        export PATH=${PATH}:${TOOLCHAIN}/go/bin
+        export GOARCH=$(go env GOARCH)
+
+        mv ${GOPATH}/src/dist/flannel-${GOARCH} /rootfs/opt/cni/bin/flannel
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
Flannel got moved out to its own repository, so we have to build it as a
separate package.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>