### PR TITLE
feat: update Linux to 5.15.6

### DIFF
--- a/kernel/kernel-prepare/pkg.yaml
+++ b/kernel/kernel-prepare/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: '{{ .TOOLS_IMAGE }}'
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.5.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.6.tar.xz
         destination: linux.tar.xz
-        sha256: e9565a301525ac81c142ceb832f9053dd5685e107dbcf753d0de4c58bc98851f
-        sha512: 7b9a78c734a24e8b67f93c8de65fb57cce498f18f4ce6a5c4cff0b834407dbf66cda6834118e67cfef3101979f2df78a7cc45854d943ffecee60a990783497df
+        sha256: b3e9ba06a299a3e2ead4a15753bc46a3e0c90d3b92ffeed1034ccc9f13a717f0
+        sha512: 0f69e98590e796a3ec3e04340fc41954f1cdb7a5859da8efec1ba4a6498760778744e6243d068bc91343e3e7029239ff2e9ee2572f458c6b0e31c23f3686b5f5
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:

--- a/kernel/kernel/config-amd64
+++ b/kernel/kernel/config-amd64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.5 Kernel Configuration
+# Linux/x86 5.15.6 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y

--- a/kernel/kernel/config-arm64
+++ b/kernel/kernel/config-arm64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.5 Kernel Configuration
+# Linux/arm64 5.15.6 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Full release notes: https://lwn.net/Articles/877286/

Please note: scsi: sd: Fix sd_do_mode_sense() buffer length handling
(disk cache may fail on 5.15.5: https://bugzilla.kernel.org/show_bug.cgi?id=215137)

Signed-off-by: Nico Berlee <nico.berlee@on2it.net>