### PR TITLE
feat: bump containerd to 1.6.0-rc.0, runc to 1.1.0

### DIFF
--- a/containerd/pkg.yaml
+++ b/containerd/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
 steps:
   - sources:
         # sync with version and revision in build
-      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.5.9.tar.gz
+      - url: https://github.com/containerd/containerd/archive/refs/tags/v1.6.0-rc.0.tar.gz
         destination: containerd.tar.gz
-        sha256: 40c9767af3e87f2c36adf2f563f0a8374e80b30bd2b7aa80058c85912406cef4
-        sha512: 13d5b8bcfd811b1abf67008d1c664962f315cd45d885adaa88847bcc4f1c5d743dccd62bc34fe77348ca18a4f8841ce7a8a022cccb275b19b59017b3fbf1054b
+        sha256: 386de511d89c1ef4364cf6c4e2bfe95b88a145398ef4460afb9e66c8b17c0aa0
+        sha512: e479e16b985f3695b2ec99ae5a928e58b7fecea81985202b6f3d71d1e1081dd216d75d845f23e20eb29bd6b0e209fd3f60552a1afacd771cdf9e68197d3009e0
     prepare:
       - |
         tar -xzf containerd.tar.gz --strip-components=1
@@ -22,7 +22,7 @@ steps:
         export CGO_ENABLED=1
         export PATH=${PATH}:${TOOLCHAIN}/go/bin
         export BUILDTAGS='seccomp no_aufs no_btrfs no_devmapper no_zfs'
-        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.5.9 REVISION=1407cab509ff0d96baa4f0eb6ff9980270e6e620
+        make bin/containerd bin/containerd-shim bin/containerd-shim-runc-v2 VERSION=v1.6.0-rc.0 REVISION=6e211a774ff0176b90894a5348964fdd9c6ce28d
     install:
       - |
         mkdir -p /rootfs/bin

--- a/runc/pkg.yaml
+++ b/runc/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
 steps:
   - sources:
       # sync with commit in build
-      - url: https://github.com/opencontainers/runc/releases/download/v1.0.3/runc.tar.xz
+      - url: https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.tar.xz
         destination: runc.tar.xz
-        sha256: e9297b338f3b382cc3a40d4c4a3bfbe8ff8db9761028691a67ea68e612d21ab6
-        sha512: 339045ac77f9691a40d1b764fe2c2a936a4c1b3f8a6ca5626c55a6b3c1812c67f406d8c26792b730d4fa3152b90cd097bbd2413301354b3bdb71b1acd0507361
+        sha256: 152e8975793aa45a6717e367bd1652f8147728d25adad339d2f70c4fd2ddc623
+        sha512: fddd9d7f874e21a718c734c85cafc0c917ba90a38a478df42c4cd4a4bc57cdce2de6462ab8f71fe39f3e926777d0e43793db841579f884076d3178e3313c4774
     prepare:
       - |
         export GOPATH=/go
@@ -27,7 +27,7 @@ steps:
         export CC=/toolchain/bin/cc
         # This is required due to "loadinternal: cannot find runtime/cgo".
         export CGO_ENABLED=1
-        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=f46b6ba2c9314cfc8caae24a32ec5fe9ef1059fe runc
+        make EXTRA_LDFLAGS="-w -s" BUILDTAGS="seccomp" COMMIT=067aaf8548d78269dcb2c13b856775e27c410f9c runc
     install:
       - |
         export GOPATH=/go


### PR DESCRIPTION
In preparation for 1.6.0 we should make sure it works fine with Talos.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>