### PR TITLE
chore: bump tools for Go 1.17.7

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.10.0-alpha.0-2-gd33b4b6
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.10.0-alpha.0-3-g4c9e7a4
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
See https://github.com/talos-systems/tools/pull/168

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>