### PR TITLE
backport: chore: update tools for Go 1.17.7

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.9.0-1-gb1146f9
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.9.0-2-gc89ed2c
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
See https://github.com/talos-systems/tools/pull/169

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>