### PR TITLE
feat: update CNI plugins to v1.1.0

### DIFF
--- a/cni/pkg.yaml
+++ b/cni/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/containernetworking/plugins/archive/refs/tags/v1.0.1.tar.gz
+      - url: https://github.com/containernetworking/plugins/archive/refs/tags/v1.1.0.tar.gz
         destination: cni-plugins.tar.gz
-        sha256: 2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619
-        sha512: 01edfb3d3c9cf34da7c97a255c9396d49b2b73a11352526d4dd7dfaa0b63e93b09261aa5f68a36f3dcf3d31c0ffd48070717abcd8a65ddb563e3402350f20352
+        sha256: c256b996fd5a1a2aea0e46a1f322be01afae0899015f65d77863693feccd32a4
+        sha512: 43cfcb0225cbc85cc75205cefac75f852fccce1a71b0384fe1f989e64c37508fc3b87cbc05c6dac679aea8950c3cd4d328a616fa79b52474561c624164da0206
     env:
       GOPATH: /go
     prepare:


### PR DESCRIPTION
See https://github.com/containernetworking/plugins/releases/tag/v1.1.0

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>