### PR TITLE
chore: Update golang to 1.17.8

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.9.0-2-gc89ed2c
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.9.0-3-g2e45da6
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
Update Golang to 1.17.8

Ref: https://github.com/talos-systems/tools/pull/174

Signed-off-by: Noel Georgi <git@frezbo.dev>