### PR TITLE
chore: bump golang to 1.17.8

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.10.0-alpha.0-5-g8197edb
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v1.0.0-1-gb63872b
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/pkgs


### PR DESCRIPTION
Bump golang to 1.17.8

Ref: https://github.com/talos-systems/tools/pull/173

Signed-off-by: Noel Georgi <git@frezbo.dev>